### PR TITLE
Add terminus compatibility branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Terminus Plugin Example
 
+[![Terminus v0.x Compatible](https://img.shields.io/badge/terminus-v0.x-green.svg)](https://github.com/pantheon-systems/terminus-plugin-example/tree/0.x)
+[![Terminus v1.x Compatible](https://img.shields.io/badge/terminus-v1.x-green.svg)](https://github.com/pantheon-systems/terminus-plugin-example/tree/1.x)
+
 A simple plugin for Terminus-CLI to demonstrate how to add new commands.
 
 This example is compatible with Terminus 1.0 or later. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terminus Plugin Example
 
-[![Terminus v0.x Compatible](https://img.shields.io/badge/terminus-v0.x-green.svg)](https://github.com/pantheon-systems/terminus-plugin-example/tree/0.x)
 [![Terminus v1.x Compatible](https://img.shields.io/badge/terminus-v1.x-green.svg)](https://github.com/pantheon-systems/terminus-plugin-example/tree/1.x)
+[![Terminus v0.x Compatible](https://img.shields.io/badge/terminus-v0.x-green.svg)](https://github.com/pantheon-systems/terminus-plugin-example/tree/0.x)
 
 A simple plugin for Terminus-CLI to demonstrate how to add new commands.
 


### PR DESCRIPTION
We should have some easily grokked standard to add to plugin readmes to indicate what version's the plugin is compatible with. This idea is a starting off point.