### PR TITLE
Add trailing backslash to namespace in autoload section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "terminus-plugin",
     "license": "MIT",
     "autoload": {
-        "psr-4": { "Pantheon\\TerminusHello": "src" }
+        "psr-4": { "Pantheon\\TerminusHello\\": "src" }
     },
     "extra": {
         "terminus": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pantheon/terminus-plugin-example",
+    "name": "pantheon-systems/terminus-plugin-example",
     "description": "An example Terminus command",
     "type": "terminus-plugin",
     "license": "MIT",


### PR DESCRIPTION
Packagist requires that namespaces in the autoload psr-4 section have trailing backslashes.