### PR TITLE
Tests using CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: quay.io/pantheon-public/php-ci:latest
+    - image: quay.io/pantheon-public/terminus-plugin-test:1.x
   working_directory: ~/work/terminus_plugin
   environment:
     BASH_ENV: ~/.bashrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+defaults: &defaults
+  docker:
+    - image: quay.io/pantheon-public/php-ci:latest
+  working_directory: ~/work/terminus_plugin
+  environment:
+    BASH_ENV: ~/.bashrc
+    TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    TERM: dumb
+
+version: 2
+jobs:
+    test:
+        <<: *defaults
+        steps:
+            - checkout
+            - run:
+                name: Set up environment
+                command: ./.circleci/set-up-globals.sh
+            - run:
+                name: Dependencies
+                command: composer install
+            - run:
+                name: Lint
+                command: composer lint
+            - run:
+                name: Unit
+                command: composer unit
+            - run:
+                name: Functional
+                command: composer functional
+            - run:
+                name: Style
+                command: composer cs
+
+workflows:
+  version: 2
+  build_test:
+    jobs:
+      - test

--- a/.circleci/set-up-globals.sh
+++ b/.circleci/set-up-globals.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#=====================================================================================================================
+# EXPORT needed environment variables
+#
+# Circle CI 2.0 does not yet expand environment variables so they have to be manually EXPORTed
+# Once environment variables can be expanded this section can be removed
+# See: https://discuss.circleci.com/t/unclear-how-to-work-with-user-variables-circleci-provided-env-variables/12810/11
+# See: https://discuss.circleci.com/t/environment-variable-expansion-in-working-directory/11322
+# See: https://discuss.circleci.com/t/circle-2-0-global-environment-variables/8681
+#=====================================================================================================================
+mkdir -p $(dirname $BASH_ENV)
+touch $BASH_ENV
+(
+  echo 'export PATH=$PATH:$HOME/bin'
+  echo 'export TERMINUS_HIDE_UPDATE_MESSAGE=1'
+) >> $BASH_ENV
+source $BASH_ENV
+
+set -ex
+
+TERMINUS_PLUGINS_DIR=.. terminus list -n remote
+
+set +ex
+echo "Test site is $TERMINUS_SITE"
+echo "Logging in with a machine token:"
+terminus auth:login -n --machine-token="$TERMINUS_TOKEN"
+terminus whoami
+touch $HOME/.ssh/config
+echo "StrictHostKeyChecking no" >> "$HOME/.ssh/config"
+git config --global user.email "$GIT_EMAIL"
+git config --global user.name "Circle CI"
+# Ignore file permissions.
+git config --global core.fileMode false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+tools

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 A simple plugin for Terminus-CLI to demonstrate how to add new commands.
 
-Adds commands 'hello' and 'auth:hello' to Terminus 1.x. For a version that works with Terminus 0.x, see the [0.x branch](https://github.com/pantheon-systems/terminus-plugin-example/tree/0.x).
-
-Learn more about Terminus and Terminus Plugins at:
+Adds commands 'hello' and 'auth:hello' to Terminus. Learn more about Terminus and Terminus Plugins at:
 [https://github.com/pantheon-systems/cli/wiki/Plugins](https://github.com/pantheon-systems/cli/wiki/Plugins)
 
 ## Configuration
@@ -26,6 +24,20 @@ On Mac OS/Linux:
 mkdir -p ~/.terminus/plugins
 curl https://github.com/pantheon-systems/terminus-plugin-example/archive/1.x.tar.gz -L | tar -C ~/.terminus/plugins -xvz
 ```
+
+## Testing
+This example project includes four testing targets:
+
+* `composer lint`: Syntax-check all php source files.
+* `composer cs`: Code-style check.
+* `composer unit`: Run unit tests with phpunit
+* `composer functional`: Run functional test with bats
+
+To run all tests together, use `composer test`.
+
+Note that prior to running the tests, you should first run:
+* `composer install`
+* `composer install-tools`
 
 ## Help
 Run `terminus help auth:hello` for help.

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,30 @@
     "autoload": {
         "psr-4": { "Pantheon\\TerminusHello\\": "src" }
     },
+    "scripts": {
+        "cs": "phpcs --standard=PSR2 -n src",
+        "cbf": "phpcbf --standard=PSR2 -n src",
+        "lint": "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
+        "unit": "phpunit --colors=always tests",
+        "functional": "TERMINUS_PLUGINS_DIR=.. ./tools/bin/bats -p -t tests/functional",
+        "install-bats": "if [ ! -f tools/bin/bats ] ; then git clone https://github.com/sstephenson/bats.git tools/bats; mkdir -p bin/bats; tools/bats/install.sh tools; fi",
+        "install-phpcs": "mkdir -p tools/phpcs && cd tools/phpcs && COMPOSER_BIN_DIR=../../vendor/bin composer require squizlabs/php_codesniffer:^2.7",
+        "install-phpunit": "mkdir -p tools/phpunit && cd tools/phpunit && COMPOSER_BIN_DIR=../../vendor/bin composer require phpunit/phpunit:^6",
+        "install-tools": [
+            "@install-bats",
+            "@install-phpcs",
+            "@install-phpunit"
+        ],
+        "test": [
+            "@lint",
+            "@unit",
+            "@functional",
+            "@cs"
+        ]
+    },
     "extra": {
         "terminus": {
-            "compatible-version": "1.*"
+            "compatible-version": "^1"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "cbf": "phpcbf --standard=PSR2 -n src",
         "lint": "find src -name '*.php' -print0 | xargs -0 -n1 php -l",
         "unit": "phpunit --colors=always tests",
-        "functional": "TERMINUS_PLUGINS_DIR=.. ./tools/bin/bats -p -t tests/functional",
-        "install-bats": "if [ ! -f tools/bin/bats ] ; then git clone https://github.com/sstephenson/bats.git tools/bats; mkdir -p bin/bats; tools/bats/install.sh tools; fi",
+        "functional": "TERMINUS_PLUGINS_DIR=.. PATH=tools/bin:$PATH bats -p -t tests/functional",
+        "install-bats": "if [ ! -f tools/bin/bats ] ; then git clone https://github.com/sstephenson/bats.git tools/bats; tools/bats/install.sh tools; fi",
         "install-phpcs": "mkdir -p tools/phpcs && cd tools/phpcs && COMPOSER_BIN_DIR=../../vendor/bin composer require squizlabs/php_codesniffer:^2.7",
         "install-phpunit": "mkdir -p tools/phpunit && cd tools/phpunit && COMPOSER_BIN_DIR=../../vendor/bin composer require phpunit/phpunit:^6",
         "install-tools": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="terminus-plugin">
+      <directory prefix="test" suffix=".php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+      <log type="coverage-clover" target="build/logs/clover.xml"/>
+  </logging>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/src/Commands/AuthHelloCommand.php
+++ b/src/Commands/AuthHelloCommand.php
@@ -25,19 +25,25 @@ class AuthHelloCommand extends TerminusCommand
      *
      * @authenticated
      */
-    public function sayHello()
+    public function sayHello($options = ['type' => 'hello'])
+    {
+        $name = $this->getAuthenticatedUserName();
+        $greeter = new Greeter($options['type']);
+        $this->log()->notice($greeter->render($name));
+    }
+
+    protected function getAuthenticatedUserName()
     {
         // Commands can retrieve information about the currently logged in user
         // by calling the `session` function to get a copy of the session object.
-        if ($user = $this->session()->getUser()) {
-            // For efficiency the logged in user's details are not automatically
-            // fetched from the API. We call `fetch` on the object to get the
-            // user's name.
-            $user->fetch();
-            // The logger can handle the replacement of variables.
-            $this->log()->notice("Hello, {user}!", ['user' => $user->getName()]);
-        } else {
-            $this->log()->notice("Hello, Anonymous!");
+        $user = $this->session()->getUser();
+        if (!$user) {
+            return 'Anonymous';
         }
+        // For efficiency the logged in user's details are not automatically
+        // fetched from the API. We call `fetch` on the object to get the
+        // user's name.
+        $user->fetch();
+        return $user->getName();
     }
 }

--- a/src/Commands/HelloCommand.php
+++ b/src/Commands/HelloCommand.php
@@ -36,8 +36,10 @@ class HelloCommand extends TerminusCommand
      *
      * @command hello
      */
-    function sayHello()
+    public function sayHello()
     {
+        $name = 'World';
+
         // All commands have access to a logger to output informational messages
         // to the user.
         // By default all messages at 'notice' or above are sent to STDERR.
@@ -45,6 +47,7 @@ class HelloCommand extends TerminusCommand
         // If you wish to output data, make it the the return value of the command
         // function so that it is sent to STDOUT to be piped to other programs, saved
         // to a file, etc.
-        $this->log()->notice("Hello, World!");
+        // Note that the logger can do variable replacement.
+        $this->log()->notice("Hello, {name}!", ['name' => $name]);
     }
 }

--- a/src/Model/Greeter.php
+++ b/src/Model/Greeter.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Example of creating a model in order to improve testability of a plugin.
+ *
+ * To write testable code:
+ *
+ *   - Write methods that take parameters and return results.
+ *   - Avoid side-effects.
+ *
+ * Use your model to determine the results of your operations. Prefer placing
+ * effects (logging, network access, etc.) in the code that calls the model.
+ * Above all else, avoid storing a reference to the dependency injection container,
+ * or any object that contains such a reference.
+ */
+
+namespace Pantheon\TerminusHello\Model;
+
+/**
+ * Say hello to the user
+ */
+class Greeter
+{
+    protected $greetingType;
+
+    /**
+     * Construct an immutable greeter. It will always be the same kind of greeter.
+     */
+    public function __construct($greetingType)
+    {
+        $this->greetingType = $greetingType;
+    }
+
+    /**
+     * Render a plesent greeting of a predetermined type.
+     */
+    public function render($name = 'World')
+    {
+        $template = $this->getGreetingTemplate($this->greetingType);
+        return strtr($template, ['{name}' => $name]);
+    }
+
+    protected function getGreetingTemplate($greetingType)
+    {
+        $templates = $this->greetingTemplates();
+        if (!isset($templates[$greetingType])) {
+            $greetingType = 'hello';
+        }
+        return $templates[$greetingType];
+    }
+
+    protected function greetingTemplates()
+    {
+        return [
+            'hello' => 'Hello, {name}!',
+            'morning' => 'Good morning, {name}!',
+            'evening' => 'Good evening, {name}!',
+        ];
+    }
+}

--- a/tests/functional/confirm-install.bats
+++ b/tests/functional/confirm-install.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+#
+# confirm-install.bats
+#
+# Ensure that Terminus and the Composer plugin have been installed correctly
+#
+
+@test "confirm terminus version" {
+  terminus --version
+}
+
+@test "get help on auth:hello command" {
+  run terminus help auth:hello
+  [[ $output == *"Say hello"* ]]
+  [ "$status" -eq 0 ]
+}

--- a/tests/unit/GreeterTest.php
+++ b/tests/unit/GreeterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pantheon\TerminusHello\Model;
+
+use PHPUnit\Framework\TestCase;
+
+class GreeterTest extends TestCase
+{
+    /**
+     * Data provider for testGreeter.
+     *
+     * Return an array of arrays, each of which contains the parameter
+     * values to be used in one invocation of the testGreeter test function.
+     */
+    public function greeterTestValues()
+    {
+        return [
+            ['Hello, World!', 'hello', 'World', ],
+            ['Good morning, Vietnam!', 'morning', 'Vietnam', ],
+            ['Good evening, Mr. Bond!', 'evening', 'Mr. Bond', ],
+        ];
+    }
+
+    /**
+     * Test our Greeter class. Each time this function is called, it will
+     * be passed data from the data provider function idendified by the
+     * dataProvider annotation.
+     *
+     * @dataProvider greeterTestValues
+     */
+    public function testGreeter($expected, $constructor_parameter, $name)
+    {
+        $greeter = new Greeter($constructor_parameter);
+        $this->assertEquals($expected, $greeter->render($name));
+    }
+}


### PR DESCRIPTION
Circle 1.0 is deprecated and will be decommissioned on 31 August 2018. All third-party plugin authors (and all Pantheon internal plugin authors) will need to upgrade their tests to Circle CI 2.0.

This PR adds Circle 2.0 tests to serve as an example of how to:
* Set up Circle 2.0 configuration file
* Use a docker image pre-loaded with Terminus and all of the tools needed for testing
* Run lint and style-checks on source code
* Run unit tests with phpunit
* Run functional tests with bats

The example has been refactored to illustrate how to create a model class with no side effects to allow for simple unit testing.

The Circle 2 docker environment is pre-configured with Terminus set up to include the system-under-test (this plugin) pre-installed. Using bats, all that tests need to do is call `terminus my:plugin:cmd` as usual via a bash script and confirm that the command output (in `$output`) and status result code (in `$status`) are correct.

To view the result of a passing test run, see: https://circleci.com/gh/greg-1-anderson/terminus-plugin-example/9. Once this PR is merged, someone with admin access on this repository will need to turn on tests on Circle 2.