### PR TITLE
ci: Add dependabot.yml for GitHub Actions (DELENG-239)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Dependabot doesn't support private repositories with actions/workflows
+    ignore:
+      - dependency-name: "pantheon-systems/*"
+


### PR DESCRIPTION
Automated addition of dependabot.yml configuration.

This configuration enables Dependabot to automatically update GitHub Actions versions used in workflows.

## Related Ticket
https://getpantheon.atlassian.net/browse/DELENG-239

## Need Help?
If you have questions or need help, ask in Slack [#ask-delivery-engineering](https://pantheon.enterprise.slack.com/archives/C09SPT0A65B)